### PR TITLE
Add Laravel migrations for legacy schema

### DIFF
--- a/database/migrations/2024_01_01_000001_create_auth_table.php
+++ b/database/migrations/2024_01_01_000001_create_auth_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('auth', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('username', 256)->unique();
+            $table->string('name', 66)->default('');
+            $table->string('password', 256);
+            $table->string('token', 64)->default('');
+            $table->char('uuid', 16);
+            $table->tinyInteger('admin');
+            $table->tinyInteger('disabled')->default(0);
+            $table->string('permissions', 2048);
+            $table->unique('uuid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('auth');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_config_table.php
+++ b/database/migrations/2024_01_01_000002_create_config_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('config', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->string('data', 2048);
+            $table->unique('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('config');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_customers_table.php
+++ b/database/migrations/2024_01_01_000003_create_customers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email', 128);
+            $table->string('name', 66);
+            $table->string('phone', 66);
+            $table->string('mobile', 66);
+            $table->string('address', 192);
+            $table->string('suburb', 66);
+            $table->string('postcode', 12)->default('');
+            $table->string('state', 66);
+            $table->string('country', 66);
+            $table->string('notes', 2048)->default('');
+            $table->string('googleid', 1024);
+            $table->string('pass', 512)->default('');
+            $table->string('token', 256)->default('');
+            $table->tinyInteger('activated')->default(0);
+            $table->tinyInteger('disabled')->default(0);
+            $table->dateTime('lastlogin')->nullable();
+            $table->dateTime('dt')->useCurrent();
+            $table->index('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customers');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_customer_contacts_table.php
+++ b/database/migrations/2024_01_01_000004_create_customer_contacts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customer_contacts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('customerid');
+            $table->string('name', 128);
+            $table->string('position', 128);
+            $table->string('phone', 66);
+            $table->string('mobile', 66);
+            $table->string('email', 128);
+            $table->tinyInteger('receivesinv');
+            $table->index('customerid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_contacts');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_locations_table.php
+++ b/database/migrations/2024_01_01_000005_create_locations_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('locations', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->dateTime('dt')->useCurrent();
+            $table->tinyInteger('disabled')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('locations');
+    }
+};

--- a/database/migrations/2024_01_01_000006_create_devices_table.php
+++ b/database/migrations/2024_01_01_000006_create_devices_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('devices', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->unsignedInteger('locationid');
+            $table->string('data', 2048);
+            $table->dateTime('dt')->useCurrent();
+            $table->tinyInteger('disabled')->default(0);
+            $table->index('locationid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('devices');
+    }
+};

--- a/database/migrations/2024_01_01_000007_create_device_map_table.php
+++ b/database/migrations/2024_01_01_000007_create_device_map_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('device_map', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('deviceid');
+            $table->string('uuid', 64);
+            $table->string('ip', 66);
+            $table->string('useragent', 256);
+            $table->dateTime('dt');
+            $table->unique('uuid');
+            $table->index('deviceid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('device_map');
+    }
+};

--- a/database/migrations/2024_01_01_000008_create_stored_suppliers_table.php
+++ b/database/migrations/2024_01_01_000008_create_stored_suppliers_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stored_suppliers', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->dateTime('dt');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stored_suppliers');
+    }
+};

--- a/database/migrations/2024_01_01_000009_create_stored_categories_table.php
+++ b/database/migrations/2024_01_01_000009_create_stored_categories_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stored_categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->dateTime('dt');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stored_categories');
+    }
+};

--- a/database/migrations/2024_01_01_000010_create_stored_items_table.php
+++ b/database/migrations/2024_01_01_000010_create_stored_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stored_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('data', 2048);
+            $table->unsignedInteger('supplierid');
+            $table->unsignedInteger('categoryid');
+            $table->string('code', 256);
+            $table->string('name', 66);
+            $table->string('price', 66);
+            $table->tinyInteger('is_variant_parent')->default(0);
+            $table->string('variant_attributes', 2048)->nullable();
+            $table->index('supplierid');
+            $table->index('categoryid');
+            $table->index('code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stored_items');
+    }
+};

--- a/database/migrations/2024_01_01_000011_create_tax_items_table.php
+++ b/database/migrations/2024_01_01_000011_create_tax_items_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tax_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->string('altname', 66);
+            $table->string('type', 12);
+            $table->string('value', 8);
+            $table->string('multiplier', 8);
+            $table->unique('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tax_items');
+    }
+};

--- a/database/migrations/2024_01_01_000012_create_tax_rules_table.php
+++ b/database/migrations/2024_01_01_000012_create_tax_rules_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tax_rules', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('altname', 66);
+            $table->string('data', 2048);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tax_rules');
+    }
+};

--- a/database/migrations/2024_01_01_000013_create_stock_levels_table.php
+++ b/database/migrations/2024_01_01_000013_create_stock_levels_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stock_levels', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('storeditemid');
+            $table->unsignedInteger('locationid');
+            $table->integer('stocklevel');
+            $table->dateTime('dt');
+            $table->unique(['storeditemid', 'locationid']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stock_levels');
+    }
+};

--- a/database/migrations/2024_01_01_000014_create_stock_history_table.php
+++ b/database/migrations/2024_01_01_000014_create_stock_history_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stock_history', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('storeditemid');
+            $table->unsignedInteger('locationid');
+            $table->unsignedInteger('auxid');
+            $table->tinyInteger('auxdir');
+            $table->string('type', 66);
+            $table->integer('amount');
+            $table->dateTime('dt');
+            $table->index('storeditemid');
+            $table->index('locationid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stock_history');
+    }
+};

--- a/database/migrations/2024_01_01_000015_create_product_attributes_table.php
+++ b/database/migrations/2024_01_01_000015_create_product_attributes_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_attributes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name', 66);
+            $table->string('display_name', 66);
+            $table->integer('sort_order')->default(0);
+            $table->dateTime('created_at')->useCurrent();
+            $table->dateTime('updated_at')->useCurrent()->useCurrentOnUpdate();
+            $table->unique('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_attributes');
+    }
+};

--- a/database/migrations/2024_01_01_000016_create_product_attribute_values_table.php
+++ b/database/migrations/2024_01_01_000016_create_product_attribute_values_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_attribute_values', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('attribute_id');
+            $table->string('value', 66);
+            $table->string('display_value', 66);
+            $table->integer('sort_order')->default(0);
+            $table->dateTime('created_at')->useCurrent();
+            $table->dateTime('updated_at')->useCurrent()->useCurrentOnUpdate();
+            $table->unique(['attribute_id', 'value']);
+            $table->index('attribute_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_attribute_values');
+    }
+};

--- a/database/migrations/2024_01_01_000017_create_product_variants_table.php
+++ b/database/migrations/2024_01_01_000017_create_product_variants_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_variants', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('product_id');
+            $table->string('sku', 256);
+            $table->string('barcode', 256)->nullable();
+            $table->string('name', 255);
+            $table->decimal('price', 12, 2)->default(0.00);
+            $table->decimal('cost', 12, 2)->default(0.00);
+            $table->tinyInteger('is_default')->default(0);
+            $table->tinyInteger('is_active')->default(1);
+            $table->dateTime('created_at')->useCurrent();
+            $table->dateTime('updated_at')->useCurrent()->useCurrentOnUpdate();
+            $table->unique(['product_id', 'sku']);
+            $table->unique('barcode');
+            $table->index('product_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_variants');
+    }
+};

--- a/database/migrations/2024_01_01_000018_create_variant_attributes_table.php
+++ b/database/migrations/2024_01_01_000018_create_variant_attributes_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('variant_attributes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('variant_id');
+            $table->unsignedInteger('attribute_id');
+            $table->unsignedInteger('attribute_value_id');
+            $table->unique(['variant_id', 'attribute_id']);
+            $table->index('attribute_id');
+            $table->index('attribute_value_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('variant_attributes');
+    }
+};

--- a/database/migrations/2024_01_01_000019_create_variant_stock_levels_table.php
+++ b/database/migrations/2024_01_01_000019_create_variant_stock_levels_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('variant_stock_levels', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('variant_id');
+            $table->unsignedInteger('locationid');
+            $table->integer('stocklevel');
+            $table->dateTime('dt')->useCurrent();
+            $table->unique(['variant_id', 'locationid']);
+            $table->index('locationid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('variant_stock_levels');
+    }
+};

--- a/database/migrations/2024_01_01_000020_create_sales_table.php
+++ b/database/migrations/2024_01_01_000020_create_sales_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sales', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('ref', 128);
+            $table->string('type', 12);
+            $table->string('channel', 12);
+            $table->string('data', 16384);
+            $table->unsignedInteger('userid');
+            $table->unsignedInteger('deviceid');
+            $table->unsignedInteger('locationid');
+            $table->unsignedInteger('custid');
+            $table->decimal('discount', 4, 0);
+            $table->decimal('rounding', 10, 2)->default(0);
+            $table->decimal('cost', 12, 2)->default(0.00);
+            $table->decimal('total', 10, 2);
+            $table->decimal('balance', 10, 2)->default(0);
+            $table->tinyInteger('status');
+            $table->unsignedBigInteger('processdt');
+            $table->unsignedBigInteger('duedt')->default(0);
+            $table->dateTime('dt');
+            $table->index('ref');
+            $table->index('custid');
+            $table->index('dt');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales');
+    }
+};

--- a/database/migrations/2024_01_01_000021_create_sale_history_table.php
+++ b/database/migrations/2024_01_01_000021_create_sale_history_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sale_history', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('saleid');
+            $table->unsignedInteger('userid');
+            $table->string('type', 66);
+            $table->string('description', 256);
+            $table->dateTime('dt');
+            $table->index('saleid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_history');
+    }
+};

--- a/database/migrations/2024_01_01_000022_create_sale_items_table.php
+++ b/database/migrations/2024_01_01_000022_create_sale_items_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sale_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('saleid');
+            $table->unsignedInteger('storeditemid');
+            $table->unsignedInteger('variant_id')->nullable();
+            $table->string('saleitemid', 12);
+            $table->integer('qty');
+            $table->string('name', 66);
+            $table->string('description', 128);
+            $table->string('taxid', 11);
+            $table->string('tax', 2048);
+            $table->tinyInteger('tax_incl')->default(1);
+            $table->decimal('tax_total', 12, 2)->default(0.00);
+            $table->decimal('cost', 12, 2)->default(0.00);
+            $table->decimal('unit_original', 12, 2)->default(0.00);
+            $table->decimal('unit', 12, 2);
+            $table->decimal('price', 12, 2);
+            $table->integer('refundqty');
+            $table->index('saleid');
+            $table->index('storeditemid');
+            $table->index('variant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_items');
+    }
+};

--- a/database/migrations/2024_01_01_000023_create_sale_payments_table.php
+++ b/database/migrations/2024_01_01_000023_create_sale_payments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sale_payments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('saleid');
+            $table->string('method', 32);
+            $table->decimal('amount', 12, 2);
+            $table->unsignedBigInteger('processdt');
+            $table->index('saleid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_payments');
+    }
+};

--- a/database/migrations/2024_01_01_000024_create_sale_voids_table.php
+++ b/database/migrations/2024_01_01_000024_create_sale_voids_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sale_voids', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('saleid');
+            $table->unsignedInteger('userid');
+            $table->unsignedInteger('deviceid');
+            $table->unsignedInteger('locationid');
+            $table->string('reason', 1024);
+            $table->string('method', 32);
+            $table->decimal('amount', 12, 2);
+            $table->string('items', 2048);
+            $table->tinyInteger('void');
+            $table->unsignedBigInteger('processdt');
+            $table->dateTime('dt');
+            $table->index('saleid');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_voids');
+    }
+};


### PR DESCRIPTION
## Summary
- add Laravel migration stubs for authentication, configuration, and customer data tables
- recreate catalog, stock, and tax tables as Laravel migrations
- provide migrations for sales workflows and newly introduced product variant tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903b70713a4832aae75bbe442236552